### PR TITLE
Add `fixup-jl` sub build command to workaound case insenstive FS problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build:js": "webpack --mode production",
     "build:backends": "dash-generate-components ./src/lib/components dash_textarea_autocomplete -p package-info.json --r-prefix '' --jl-prefix ''",
     "build:backends-activated": "(. venv/bin/activate || venv\\scripts\\activate && npm run build:py_and_r)",
-    "build": "npm run build:js && npm run build:backends",
+    "build:fixup-jl": "mkdir -p src/jl && mv -f src/dashtextareaautocomplete.jl src/jl/ && sed -i 's/include(\"dashtextareaautocomplete.jl\")/include(\"jl\\/dashtextareaautocomplete.jl\")/' src/DashTextareaAutocomplete.jl",
+    "build": "npm run build:js && npm run build:backends && npm run build:fixup-jl",
     "build:activated": "npm run build:js && npm run build:backends-activated"
   },
   "author": "Etienne Tetreault-Pinard <info@etpinard.xyz>",


### PR DESCRIPTION
https://github.com/etpinard/dash-textarea-autocomplete/issues/7 needs to be fixed, looks like https://github.com/plotly/dash/pull/1567 won't get merged anytime soon, so here's a hacky (but reproducible) workaround

cc @Felix-Gauthier 

I'll make a release tomorrow that includes this fix.