### PR TITLE
Fix `external_url` links and add `Manifest.toml` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -272,3 +272,6 @@ bh_unicode_properties.cache
 # Sublime-github package stores a github token in this file
 # https://packagecontrol.io/packages/sublime-github
 GitHub.sublime-settings
+
+# Julia Manifest file
+Manifest.toml

--- a/src/DashTextareaAutocomplete.jl
+++ b/src/DashTextareaAutocomplete.jl
@@ -16,14 +16,14 @@ function __init__()
             [
                 DashBase.Resource(
     relative_package_path = "dash_textarea_autocomplete.min.js",
-    external_url = "https://unpkg.com/dash_textarea_autocomplete@1.1.0/dash_textarea_autocomplete/dash_textarea_autocomplete.min.js",
+    external_url = "https://unpkg.com/dash-textarea-autocomplete@1.1.0/dash_textarea_autocomplete/dash_textarea_autocomplete.min.js",
     dynamic = nothing,
     async = nothing,
     type = :js
 ),
 DashBase.Resource(
     relative_package_path = "dash_textarea_autocomplete.min.js.map",
-    external_url = "https://unpkg.com/dash_textarea_autocomplete@1.1.0/dash_textarea_autocomplete/dash_textarea_autocomplete.min.js.map",
+    external_url = "https://unpkg.com/dash-textarea-autocomplete@1.1.0/dash_textarea_autocomplete/dash_textarea_autocomplete.min.js.map",
     dynamic = true,
     async = nothing,
     type = :js


### PR DESCRIPTION
Fixes `external_url` links with working ones

I wasn't fully able to understand exactly where this issue occured from `dash.py` but luckily understanding it isn't necessary to fix it

@etpinard is there any special considerations for a version bump ?