### PR TITLE
Fix incorrect url for `unpkg.com`

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -3,4 +3,4 @@ git-tree-sha1 = "40556a4d143e9e1b25db0e0f434e9415989b3385"
 
     [[dash_textarea_autocomplete_resources.download]]
     sha256 = "5b3b5fb207ce04e53c3a91bbe9378e794b49d8017351c3e142eb4353e107d113"
-    url = "https://unpkg.com/dash-textarea-autocomplete@1.2.0/dash_textarea_autocomplete/deps.tar.gz"
+    url = "https://unpkg.com/dash-textarea-autocomplete@1.2.0/deps/deps.tar.gz"


### PR DESCRIPTION
Fixes the bad url, the `@1.2.0` part of the string will be updated during the version bump process by `postbuild.sh`