### PR TITLE
Fix unpkg.com url for `serve_locally=False` apps

### DIFF
--- a/dash_textarea_autocomplete/__init__.py
+++ b/dash_textarea_autocomplete/__init__.py
@@ -21,7 +21,8 @@ _filepath = _os.path.abspath(_os.path.join(_basepath, 'package-info.json'))
 with open(_filepath) as f:
     package = json.load(f)
 
-package_name = package['name'].replace(' ', '_').replace('-', '_')
+js_name = package['name']
+package_name = js_name.replace(' ', '_').replace('-', '_')
 __version__ = package['version']
 
 _current_path = _os.path.dirname(_os.path.abspath(__file__))
@@ -33,13 +34,13 @@ _js_dist = [
     {
         'relative_package_path': 'dash_textarea_autocomplete.min.js',
 'external_url': 'https://unpkg.com/{0}@{2}/{1}/{1}.min.js'.format(
-            package_name, __name__, __version__),
+            js_name, __name__, __version__),
         'namespace': package_name
     },
     {
         'relative_package_path': 'dash_textarea_autocomplete.min.js.map',
 'external_url': 'https://unpkg.com/{0}@{2}/{1}/{1}.min.js.map'.format(
-            package_name, __name__, __version__),
+            js_name, __name__, __version__),
         'namespace': package_name,
         'dynamic': True
     }

--- a/postbuild_fixups.sh
+++ b/postbuild_fixups.sh
@@ -4,7 +4,6 @@ version=${1?Please specify version}
 
 # src/DashTextareaAutocomplete
 declare -a moduleregs=(\
-'s/https:\/\/unpkg.com\/dash_textarea_autocomplete/https:\/\/unpkg.com\/dash-textarea-autocomplete/' \
 's/const resources_path = realpath(joinpath( @__DIR__, \"..\", \"deps\"))/resources_path() = artifact\"dash_textarea_autocomplete_resources\"/' \
 's/using Dash/using Dash, Pkg.Artifacts/' \
 's/            resources_path,/            resources_path(),/' \


### PR DESCRIPTION
I was about to submit a PR to [plotly/dash](https://github.com/plotly/dash/), when I realised that our problems with the unpkg.com URLs were entirely caused by ... me :facepalm: 

Back in https://github.com/etpinard/dash-textarea-autocomplete/commit/75ab848ba4f8f714aa8ed45972aa16682315df5a, I decided to replace `_`  to `-` in the `package.json` name field to follow the convention that other dash component packages are using like e.g. `dash-core-components` (on [npm](https://www.npmjs.com/package/dash-core-components) and [pypi](https://pypi.org/project/dash-core-components/)). But in turn, this change parted ways with the [`dash-component-boilerplate`](https://github.com/plotly/dash-component-boilerplate) template and made the [`__init__.py` template file](https://github.com/plotly/dash-component-boilerplate/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/%7B%7Bcookiecutter.project_shortname%7D%7D/__init__.py) not function as planned.

I also learned that these unpkg.com URLs are used when the `serve_locally` dash app option is turned off. So starting with the [`usage.py`](https://github.com/etpinard/dash-textarea-autocomplete/blob/main/usage.py) and applying this patch

```diff
--- a/usage.py
+++ b/usage.py
@@ -7,7 +7,8 @@ WORD_LIST = ['apple', 'application', 'apartment',

 external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']

-app = Dash(__name__, external_stylesheets=external_stylesheets)
+app = Dash(__name__, external_stylesheets=external_stylesheets,
+           serve_locally=False)

 app.layout = html.Div([
     dash_textarea_autocomplete.DashTextareaAutocomplete(
@@ -40,4 +41,4 @@ def display_output2(n_clicks, value):


 if __name__ == '__main__':
-    app.run_server(debug=True)
+    app.run_server()
```

currently gives:

![image](https://user-images.githubusercontent.com/6675409/146595379-f0a766b2-b762-4b96-b095-64f9cdf4ff04.png)

----

Fixing this `__init__.py` file makes the sed fixup unnecessary as `dash-generate-components` script [uses the `__init__.py` file](https://github.com/plotly/dash/blob/94cbc3b8c06a7cf1d473cfa54abf6eb796c775e3/dash/development/_jl_components_generation.py#L353) to generate the `src/DashTextareaAutocomplete.jl` content. 

cc @Felix-Gauthier 